### PR TITLE
Update javaagent example

### DIFF
--- a/javaagent/Dockerfile
+++ b/javaagent/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre
 
-ADD build/libs/opentelemetry-examples-javaagent-*-SNAPSHOT.jar /app.jar
-ADD build/otel/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
+ADD build/libs/app.jar /app.jar
+ADD build/agent/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar
 
-ENTRYPOINT java -jar -javaagent:/opentelemetry-javaagent.jar app.jar
+ENTRYPOINT java -jar -javaagent:/opentelemetry-javaagent.jar /app.jar

--- a/javaagent/build.gradle
+++ b/javaagent/build.gradle
@@ -2,18 +2,14 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.13'
     id 'io.spring.dependency-management' version '1.1.2'
-    id 'de.undercouch.download' version '5.4.0'
 }
 
 description = 'OpenTelemetry Example for Java Agent'
 ext.moduleName = "io.opentelemetry.examples.javagent"
 
-bootRun {
-    mainClass.set 'io.opentelemetry.example.javagent.Application'
-}
-
-bootJar {
-    dependsOn("downloadAgent")
+configurations {
+    // create a separate configuration for the agent since it should not be a normal dependency
+    agent
 }
 
 dependencies {
@@ -21,11 +17,18 @@ dependencies {
 
     //spring modules
     implementation("org.springframework.boot:spring-boot-starter-web")
+
+    agent("io.opentelemetry.javaagent:opentelemetry-javaagent:1.28.0")
 }
 
-// Download the OpenTelemetry java agent and put it in the build directory
-task downloadAgent(type: Download) {
-    src "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
-    dest project.buildDir.toString() + "/otel/opentelemetry-javaagent.jar"
-    overwrite true
+def copyAgent = tasks.register('copyAgent', Copy) {
+    from configurations.agent.singleFile
+    into layout.buildDirectory.dir('agent')
+    rename 'opentelemetry-javaagent-.*\\.jar', 'opentelemetry-javaagent.jar'
+}
+
+bootJar {
+    dependsOn copyAgent
+
+    archiveFileName = 'app.jar'
 }


### PR DESCRIPTION
PRO: this avoids using a 3rd party gradle plugin (`de.undercouch.download`)

CON: it relies on defining a custom gradle configuration which is maybe not as clear