### PR TITLE
Kotlin extension - coroutines example

### DIFF
--- a/kotlin-extension/README.md
+++ b/kotlin-extension/README.md
@@ -1,0 +1,24 @@
+# Kotlin Extension examples
+
+This is a simple example that demonstrates how to use the Kotlin extension for attaching a Span context to a Kotlin
+coroutine.
+
+## Prerequisites
+
+* Java 1.8 or higher
+
+## Compile
+
+Compile with
+
+```shell script
+../gradlew shadowJar
+```
+
+## Run
+
+The following commands are used to run the examples.
+
+```shell script
+java -cp build/libs/kotlin-extension-0.1.0-SNAPSHOT-all.jar io.opentelemetry.example.kotlinextension.Application
+```

--- a/kotlin-extension/build.gradle
+++ b/kotlin-extension/build.gradle
@@ -4,9 +4,9 @@ plugins {
 
 description = 'OpenTelemetry Example for Kotlin extensions'
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        jvmTarget = "1.8"
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
     }
 }
 

--- a/kotlin-extension/build.gradle
+++ b/kotlin-extension/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.9.0'
+}
+
+description = 'OpenTelemetry Example for Kotlin extensions'
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("io.opentelemetry:opentelemetry-extension-kotlin")
+}

--- a/kotlin-extension/build.gradle
+++ b/kotlin-extension/build.gradle
@@ -12,4 +12,6 @@ kotlin {
 
 dependencies {
     implementation("io.opentelemetry:opentelemetry-extension-kotlin")
+    implementation("io.opentelemetry:opentelemetry-sdk-testing")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
@@ -1,15 +1,13 @@
 package io.opentelemetry.example.kotlinextension
 
-import java.util.concurrent.CountDownLatch
+import kotlinx.coroutines.runBlocking
 
 object Application {
 
     @JvmStatic
     fun main(vararg args: String) {
-        val countDownLatch = CountDownLatch(1)
-
-        CoroutineContextExample().run(countDownLatch)
-
-        countDownLatch.await()
+        runBlocking {
+            CoroutineContextExample().run()
+        }
     }
 }

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
@@ -1,0 +1,9 @@
+package io.opentelemetry.example.kotlinextension
+
+object Application {
+
+    @JvmStatic
+    fun main(vararg args: String){
+
+    }
+}

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/Application.kt
@@ -1,9 +1,15 @@
 package io.opentelemetry.example.kotlinextension
 
+import java.util.concurrent.CountDownLatch
+
 object Application {
 
     @JvmStatic
-    fun main(vararg args: String){
+    fun main(vararg args: String) {
+        val countDownLatch = CountDownLatch(1)
 
+        CoroutineContextExample().run(countDownLatch)
+
+        countDownLatch.await()
     }
 }

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
@@ -1,0 +1,79 @@
+package io.opentelemetry.example.kotlinextension
+
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.CountDownLatch
+
+/**
+ * This example aims to show how to embed a Span context within a Kotlin coroutine so that any new span created inside the
+ * coroutine will automatically get the Span context provided for the coroutine even if said new span is created after
+ * changing the coroutine's thread.
+ */
+class CoroutineContextExample {
+    private val inMemoryExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+    private val tracer by lazy { createTracer() }
+
+    fun run(countDownLatch: CountDownLatch) {
+        val rootSpan = tracer.spanBuilder("Root span").startSpan()
+
+        val rootScope = rootSpan.makeCurrent()
+        println("Root span trace ID: ${rootSpan.spanContext.traceId}")
+
+        // Create the coroutine scope to launch it later.
+        val scope = CoroutineScope(Dispatchers.IO)
+
+        // Launching a coroutine with the Span context embedded in its [the coroutine's] context. The `asContextElement` is a Kotlin
+        // extension function that ensures that the Span context will be preserved across the life of the coroutine
+        // regardless of any "thread change" (coroutine context change) that might happen inside the coroutine.
+        // We could also look at the line below as if we'd call `span.makeCurrent` but for a Kotlin coroutine. So after
+        // launching the coroutine this way (with the embedded Span context) any new span created inside the coroutine
+        // must automatically get our root span as its parent.
+
+        // Bonus: If we wanted to launch a coroutine in a separate thread (not IO, which is the one set in the scope) while
+        // keeping the Span context too, we could do so like this:
+        // scope.launch(Dispatchers.Main + Context.current().asContextElement())
+        scope.launch(Context.current().asContextElement()) {
+            // Creating spans that must have the rootSpan as their parent since its context is attached to the
+            // coroutine context.
+            createChildrenSpans()
+
+            rootScope.close()
+            rootSpan.end()
+
+            val finishedSpanItems = inMemoryExporter.finishedSpanItems
+            println("First child's trace id: ${finishedSpanItems[1].traceId}") // The same as the root span's.
+            println("Second child's trace id: ${finishedSpanItems[2].traceId}") // The same as the root span's.
+
+            // Release the main thread.
+            countDownLatch.countDown()
+        }
+    }
+
+    private suspend fun createChildrenSpans() {
+        // Creating a span within the same coroutine context that the coroutine was created with.
+        val firstChildSpan = tracer.spanBuilder("First child").startSpan()
+        firstChildSpan.end()
+
+        // Switching coroutine's thread to show that the Span context is preserved even after changing the context of
+        // the running coroutine.
+        withContext(Dispatchers.Default) {
+            val secondChild = tracer.spanBuilder("Second child").startSpan()
+            secondChild.end()
+        }
+    }
+
+    private fun createTracer(): Tracer {
+        return SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(inMemoryExporter))
+                .build()
+                .get("TestInstrumentation")
+    }
+}

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
@@ -59,8 +59,8 @@ class CoroutineContextExample {
         val secondChildSpanData = finishedSpanItems[2]
 
         println("Root span's trace id: ${rootSpanData.traceId} and thread.id: ${rootSpanData.attributes.get(ATTR_THREAD_ID)}")
-        println("First child's trace id: ${firstChildSpanData.traceId} and thread.id: ${firstChildSpanData.attributes.get(ATTR_THREAD_ID)}") // The same as the root span's.
-        println("Second child's trace id: ${secondChildSpanData.traceId} and thread.id: ${secondChildSpanData.attributes.get(ATTR_THREAD_ID)}") // The same as the root span's.
+        println("First child's trace id: ${firstChildSpanData.traceId} and thread.id: ${firstChildSpanData.attributes.get(ATTR_THREAD_ID)}") // The trace id should be the same as the root span's.
+        println("Second child's trace id: ${secondChildSpanData.traceId} and thread.id: ${secondChildSpanData.attributes.get(ATTR_THREAD_ID)}") // The trace id should be the same as the root span's.
     }
 
     private suspend fun createChildrenSpans() {

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
@@ -27,7 +27,7 @@ class CoroutineContextExample {
     }
 
     suspend fun run() {
-        val rootSpan = createSpanWithThreadNameAttr("Root span")
+        val rootSpan = createSpanWithThreadIdAttr("Root span")
 
         rootSpan.makeCurrent().use {
             // Create the coroutine scope to launch it later.
@@ -65,13 +65,13 @@ class CoroutineContextExample {
 
     private suspend fun createChildrenSpans() {
         // Creating a span within the same coroutine context that the coroutine was created with.
-        val firstChildSpan = createSpanWithThreadNameAttr("First child")
+        val firstChildSpan = createSpanWithThreadIdAttr("First child")
         firstChildSpan.end()
 
         // Switching coroutine's thread to show that the Span context is preserved even after changing the context of
         // the running coroutine.
         withContext(Dispatchers.Default) {
-            val secondChild = createSpanWithThreadNameAttr("Second child")
+            val secondChild = createSpanWithThreadIdAttr("Second child")
             secondChild.end()
         }
     }
@@ -83,7 +83,7 @@ class CoroutineContextExample {
                 .get("TestInstrumentation")
     }
 
-    private fun createSpanWithThreadNameAttr(name: String): Span {
+    private fun createSpanWithThreadIdAttr(name: String): Span {
         val spanBuilder = tracer.spanBuilder(name)
                 .setAttribute(ATTR_THREAD_ID, Thread.currentThread().id)
         return spanBuilder.startSpan()

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
@@ -48,9 +48,9 @@ class CoroutineContextExample {
                 // coroutine context.
                 createChildrenSpans()
             }.join()
-
-            rootSpan.end()
         }
+
+        rootSpan.end()
 
         // Verifying that all the spans created inside the coroutine are children of the root span.
         val finishedSpanItems = inMemoryExporter.finishedSpanItems

--- a/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
+++ b/kotlin-extension/src/main/kotlin/io/opentelemetry/example/kotlinextension/CoroutineContextExample.kt
@@ -40,7 +40,7 @@ class CoroutineContextExample {
             // launching the coroutine this way (with the embedded Span context) any new span created inside the coroutine
             // must automatically get our root span as its parent.
 
-            // Bonus: If we wanted to launch a coroutine in a separate thread (not IO, which is the one set in the scope) while
+            // Bonus: If we wanted to launch a coroutine in a different thread (not IO, which is the one set in the scope) while
             // keeping the Span context too, we could do so like this:
             // scope.launch(Dispatchers.Main + Context.current().asContextElement())
             scope.launch(Context.current().asContextElement()) {
@@ -84,8 +84,7 @@ class CoroutineContextExample {
     }
 
     private fun createSpanWithThreadIdAttr(name: String): Span {
-        val spanBuilder = tracer.spanBuilder(name)
-                .setAttribute(ATTR_THREAD_ID, Thread.currentThread().id)
-        return spanBuilder.startSpan()
+        return tracer.spanBuilder(name)
+                .setAttribute(ATTR_THREAD_ID, Thread.currentThread().id).startSpan()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,7 +62,7 @@ include ":opentelemetry-examples-autoconfigure",
         ":opentelemetry-examples-telemetry-testing",
         ":opentelemetry-examples-zipkin",
         ":opentelemetry-examples-spring-native",
-        ":kotlin-extension"
+        ":opentelemetry-examples-kotlin-extension"
 
 rootProject.children.each {
     it.projectDir = "$rootDir/" + it.name

--- a/settings.gradle
+++ b/settings.gradle
@@ -61,7 +61,8 @@ include ":opentelemetry-examples-autoconfigure",
         ":opentelemetry-examples-sdk-usage",
         ":opentelemetry-examples-telemetry-testing",
         ":opentelemetry-examples-zipkin",
-        ":opentelemetry-examples-spring-native"
+        ":opentelemetry-examples-spring-native",
+        ":kotlin-extension"
 
 rootProject.children.each {
     it.projectDir = "$rootDir/" + it.name


### PR DESCRIPTION
This is an example of how to use the `Context.asContextElement` extension function provided in the OTel Java [Kotlin extension library](https://github.com/open-telemetry/opentelemetry-java/tree/main/extensions/kotlin) in order to preserve a Span context across a coroutine, even if its thread changes.