### PR TITLE
Rework metrics examples

### DIFF
--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -13,4 +13,8 @@ java {
 
 dependencies {
     implementation("io.opentelemetry:opentelemetry-api")
+
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
+    runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
+    implementation("io.opentelemetry:opentelemetry-extension-incubator")
 }

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/GaugeExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/GaugeExample.java
@@ -1,8 +1,9 @@
 package io.opentelemetry.example.metrics;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 
 /**
  * Example of using a Long Gauge to measure execution time of method. The gauge callback will get
@@ -12,7 +13,8 @@ import io.opentelemetry.api.metrics.Meter;
 public final class GaugeExample {
 
   public static void main(String[] args) {
-    Meter sampleMeter = GlobalOpenTelemetry.getMeter("io.opentelemetry.example.metrics");
+    OpenTelemetry sdk = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+    Meter sampleMeter = sdk.getMeter("io.opentelemetry.example.metrics");
 
     sampleMeter
         .gaugeBuilder("jvm.memory.total")

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/HistogramExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/HistogramExample.java
@@ -57,12 +57,16 @@ public class HistogramExample {
   /**
    * This example is just like the above, except that instead of using the default bucket
    * boundaries, we pass a list of custom bucket boundaries.
+   *
+   * <p>Please note that the Advisory parameters API is not yet stable and are subject to change.
+   * You may check with <a
+   * href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-advisory-parameters">the
+   * specification</a> for the latest status of the api.
    */
   void exampleWithCustomBuckets(Meter meter) {
     DoubleHistogramBuilder originalBuilder = meter.histogramBuilder("people.ages");
     ExtendedLongHistogramBuilder builder = (ExtendedLongHistogramBuilder) originalBuilder.ofLongs();
-    List<Double> bucketBoundaries =
-        Arrays.asList(0.0, 5.0, 12.0, 18.0, 24.0, 40.0, 50.0, 80.0, 115.0);
+    List<Long> bucketBoundaries = Arrays.asList(0L, 5L, 12L, 18L, 24L, 40L, 50L, 80L, 115L);
     LongHistogram histogram =
         builder
             .setAdvice(advice -> advice.setExplicitBucketBoundaries(bucketBoundaries))

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/HistogramExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/HistogramExample.java
@@ -2,11 +2,15 @@ package io.opentelemetry.example.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.extension.incubator.metrics.ExtendedLongHistogramBuilder;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -14,32 +18,66 @@ public class HistogramExample {
 
   private final OpenTelemetry otel;
 
+  public static void main(String[] args) {
+    // The default export interval is 30s, but can be customized to something shorter.
+    // Typically, this would be done with an external property or env var.
+    System.setProperty("otel.metric.export.interval", "10000");
+    OpenTelemetry sdk = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+    new HistogramExample(sdk).run();
+  }
+
   public HistogramExample(OpenTelemetry otel) {
     this.otel = otel;
   }
 
-  private void run() {
+  void run() {
     Meter meter = otel.getMeter("io.opentelemetry.example.metrics");
+    exampleWithDefaultBuckets(meter);
+    exampleWithCustomBuckets(meter);
+  }
 
+  /**
+   * This example shows how to create a LongHistogram with a description and a unit. It then calls a
+   * method to populate the histogram with some randomly generated data. This method uses the
+   * default bucket boundaries <a
+   * href="https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation">documented
+   * here</a>
+   */
+  void exampleWithDefaultBuckets(Meter meter) {
     LongHistogram histogram =
         meter
             .histogramBuilder("people.ages")
+            .ofLongs() // Required to get a LongHistogram, default is DoubleHistogram
             .setDescription("A distribution of people's ages")
             .setUnit("years")
-            .ofLongs()
             .build();
+    addDataToHistogram(histogram);
+  }
 
+  /**
+   * This example is just like the above, except that instead of using the default bucket
+   * boundaries, we pass a list of custom bucket boundaries.
+   */
+  void exampleWithCustomBuckets(Meter meter) {
+    DoubleHistogramBuilder originalBuilder = meter.histogramBuilder("people.ages");
+    ExtendedLongHistogramBuilder builder = (ExtendedLongHistogramBuilder) originalBuilder.ofLongs();
+    List<Double> bucketBoundaries =
+        Arrays.asList(0.0, 5.0, 12.0, 18.0, 24.0, 40.0, 50.0, 80.0, 115.0);
+    LongHistogram histogram =
+        builder
+            .setAdvice(advice -> advice.setExplicitBucketBoundaries(bucketBoundaries))
+            .setDescription("A distribution of people's ages")
+            .setUnit("years")
+            .build();
+    addDataToHistogram(histogram);
+  }
+
+  void addDataToHistogram(LongHistogram histogram) {
     Random rand = new Random();
     Attributes attrs =
         Attributes.of(
             stringKey("decade"), "1990s",
             stringKey("source"), "someAlmanac");
     IntStream.range(0, 1000).forEach(x -> histogram.record(rand.nextLong(115), attrs));
-  }
-
-  public static void main(String[] args) {
-    System.setProperty("otel.metric.export.interval", "10000");
-    OpenTelemetry sdk = GlobalOpenTelemetry.get();
-    new HistogramExample(sdk).run();
   }
 }

--- a/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
+++ b/metrics/src/main/java/io/opentelemetry/example/metrics/LongCounterExample.java
@@ -2,7 +2,7 @@ package io.opentelemetry.example.metrics;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
-import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -12,36 +12,41 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.io.File;
 import javax.swing.filechooser.FileSystemView;
 
 /** Example of using {@link LongCounter} to count searched directories. */
 public final class LongCounterExample {
 
-  private static final Tracer tracer =
-      GlobalOpenTelemetry.getTracer("io.opentelemetry.example.metrics", "0.13.1");
-
-  private static final Meter sampleMeter =
-      GlobalOpenTelemetry.getMeter("io.opentelemetry.example.metrics");
-  private static final LongCounter directoryCounter =
-      sampleMeter
-          .counterBuilder("directories_search_count")
-          .setDescription("Counts directories accessed while searching for files.")
-          .setUnit("unit")
-          .build();
+  public static final String INSTRUMENTATION_SCOPE = "io.opentelemetry.example.metrics";
   private static final File homeDirectory = FileSystemView.getFileSystemView().getHomeDirectory();
 
   private static final AttributeKey<String> ROOT_DIRECTORY_KEY = stringKey("root directory");
   // statically allocate the attributes, since they are known at init time.
   private static final Attributes HOME_DIRECTORY_ATTRIBUTES =
       Attributes.of(ROOT_DIRECTORY_KEY, homeDirectory.getName());
+  private final Meter meter;
+  private final Tracer tracer;
+
+  public LongCounterExample(Tracer tracer, Meter meter) {
+    this.tracer = tracer;
+    this.meter = meter;
+  }
 
   public static void main(String[] args) {
+    OpenTelemetry sdk = AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+    Tracer tracer = sdk.getTracer(INSTRUMENTATION_SCOPE, "0.13.1");
+    Meter meter = sdk.getMeter(INSTRUMENTATION_SCOPE);
+    LongCounterExample example = new LongCounterExample(tracer, meter);
+    example.run();
+  }
+
+  void run() {
     Span span = tracer.spanBuilder("workflow").setSpanKind(SpanKind.INTERNAL).startSpan();
-    LongCounterExample example = new LongCounterExample();
     try (Scope scope = span.makeCurrent()) {
+      LongCounter directoryCounter = findFile("file_to_find.txt", homeDirectory);
       directoryCounter.add(1, HOME_DIRECTORY_ATTRIBUTES); // count root directory
-      example.findFile("file_to_find.txt", homeDirectory);
     } catch (Exception e) {
       span.setStatus(StatusCode.ERROR, "Error while finding file");
     } finally {
@@ -49,18 +54,33 @@ public final class LongCounterExample {
     }
   }
 
-  public void findFile(String name, File directory) {
+  /**
+   * Uses the Meter instance to create a LongCounter with the given name, description, and units.
+   * This is the counter that is used to count directories during filesystem traversal.
+   */
+  LongCounter createCounter() {
+    return meter
+        .counterBuilder("directories_search_count")
+        .setDescription("Counts directories accessed while searching for files.")
+        .setUnit("unit")
+        .build();
+  }
+
+  LongCounter findFile(String name, File directory) {
+    LongCounter directoryCounter = createCounter();
     File[] files = directory.listFiles();
     System.out.println("Currently looking at " + directory.getAbsolutePath());
-    if (files != null) {
-      for (File file : files) {
-        if (file.isDirectory()) {
-          directoryCounter.add(1, HOME_DIRECTORY_ATTRIBUTES);
-          findFile(name, file);
-        } else if (name.equalsIgnoreCase(file.getName())) {
-          System.out.println(file.getParentFile());
-        }
+    if (files == null) {
+      return directoryCounter;
+    }
+    for (File file : files) {
+      if (file.isDirectory()) {
+        directoryCounter.add(1, HOME_DIRECTORY_ATTRIBUTES);
+        findFile(name, file);
+      } else if (name.equalsIgnoreCase(file.getName())) {
+        System.out.println(file.getParentFile());
       }
     }
+    return directoryCounter;
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -63,8 +63,8 @@ include ":opentelemetry-examples-autoconfigure",
         ":opentelemetry-examples-prometheus",
         ":opentelemetry-examples-sdk-usage",
         ":opentelemetry-examples-telemetry-testing",
-        ":opentelemetry-examples-zipkin",
-        ":opentelemetry-examples-spring-native",
+        ":opentelemetry-examples-zipkin"
+//        ":opentelemetry-examples-spring-native",
         ":opentelemetry-examples-kotlin-extension"
 
 rootProject.children.each {

--- a/settings.gradle
+++ b/settings.gradle
@@ -63,8 +63,8 @@ include ":opentelemetry-examples-autoconfigure",
         ":opentelemetry-examples-prometheus",
         ":opentelemetry-examples-sdk-usage",
         ":opentelemetry-examples-telemetry-testing",
-        ":opentelemetry-examples-zipkin"
-//        ":opentelemetry-examples-spring-native",
+        ":opentelemetry-examples-zipkin",
+        ":opentelemetry-examples-spring-native",
         ":opentelemetry-examples-kotlin-extension"
 
 rootProject.children.each {


### PR DESCRIPTION
I lost track of the fact that I had already submitted the histogram example. So anyway, this updates it a little bit to include custom buckets. I'm not stoked on the cast required in the bucket example, but I think it's all we have right now. Happy to remove it if we think it's premature.

I also changed the other examples to use the autoconfigured SDK so that folks can actually run them in their IDE without getting the noop implementations.
