### PR TITLE
Remove snapshot repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,6 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            // Add snapshot repository
-            url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
     }
 
     compileJava {


### PR DESCRIPTION
Hoping maybe this is why renovate (and dependabot previously) isn't picking up new version for:

https://github.com/open-telemetry/opentelemetry-java-examples/blob/15f9aeba2e356fe71a4ccc19028a72e8d2b7bbf9/telemetry-testing/build.gradle#L39
