### PR TITLE
Demonstrate file based configuration of RuleBasedRoutingSampler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ subprojects {
 
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 
     dependencies {

--- a/file-configuration/build.gradle
+++ b/file-configuration/build.gradle
@@ -1,18 +1,25 @@
 plugins {
     id 'java'
-    id 'application'
+    id 'org.springframework.boot' version '2.7.16'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 description = 'OpenTelemetry Example for File Configuration'
 ext.moduleName = "io.opentelemetry.examples.fileconfig"
 
 dependencies {
+    //spring modules
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    implementation platform('io.opentelemetry:opentelemetry-bom-alpha:1.31.0-alpha-SNAPSHOT')
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
     implementation("io.opentelemetry:opentelemetry-exporter-logging")
     implementation("io.opentelemetry:opentelemetry-sdk-extension-incubator")
-}
 
-application {
-    mainClass = 'io.opentelemetry.examples.fileconfig.Application'
+    implementation "io.opentelemetry.contrib:opentelemetry-samplers:1.31.0-alpha-SNAPSHOT"
+
+    implementation platform('io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.29.0-alpha')
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-webmvc-5.3'
 }

--- a/file-configuration/otel-sdk-config.yaml
+++ b/file-configuration/otel-sdk-config.yaml
@@ -10,17 +10,16 @@ tracer_provider:
     - batch:
         exporter:
           console: {}
-
-meter_provider:
-  readers:
-    - periodic:
-        exporter:
-          console: {}
-  views:
-    - selector:
-        instrument_type: histogram
-      stream:
-        aggregation:
-          drop: {}
+  sampler:
+    parent_based:
+      root:
+        rule_based_routing_sampler:
+          fallback: always_on
+          span_kind: SERVER
+          drop_rules:
+            - attribute: http.target
+              pattern: "/actuator.*"
+            - attribute: http.target
+              pattern: "/foo"
 
 propagators: [tracecontext, baggage]

--- a/file-configuration/src/main/java/io/opentelemetry/examples/fileconfig/Controller.java
+++ b/file-configuration/src/main/java/io/opentelemetry/examples/fileconfig/Controller.java
@@ -1,0 +1,52 @@
+package io.opentelemetry.examples.fileconfig;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import java.util.Random;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  private static final Logger LOGGER = LogManager.getLogger(Controller.class);
+  private final AttributeKey<String> ATTR_METHOD = AttributeKey.stringKey("method");
+
+  private final Random random = new Random();
+  private final Tracer tracer;
+  private final LongHistogram doWorkHistogram;
+
+  @Autowired
+  Controller(OpenTelemetry openTelemetry) {
+    tracer = openTelemetry.getTracer(Application.class.getName());
+    Meter meter = openTelemetry.getMeter(Application.class.getName());
+    doWorkHistogram = meter.histogramBuilder("do-work").ofLongs().build();
+  }
+
+  @GetMapping("/ping")
+  public String ping() throws InterruptedException {
+    int sleepTime = random.nextInt(200);
+    doWork(sleepTime);
+    doWorkHistogram.record(sleepTime, Attributes.of(ATTR_METHOD, "ping"));
+    return "pong";
+  }
+
+  private void doWork(int sleepTime) throws InterruptedException {
+    Span span = tracer.spanBuilder("doWork").startSpan();
+    try (Scope ignored = span.makeCurrent()) {
+      Thread.sleep(sleepTime);
+      LOGGER.info("A sample log message!");
+    } finally {
+      span.end();
+    }
+  }
+}


### PR DESCRIPTION
This demonstrates how file based configuration can be used to easily configure [RuleBasedRoutingSampler](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/samplers/src/main/java/io/opentelemetry/contrib/sampler/RuleBasedRoutingSampler.java) to drop spans with match a particular pattern. It requires changes to several repos, but if the changes were adopted and file configuration and `RuleBasedRoutingSampler` were enabled in the java agent, this would effectively solve [Exclude URLs from Tracing](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/1060) (the most upvoted open issue in opentelemetry-java-instrumentation).

Other required changes:
- Add support for loading SPIs to file configuration, [like this commit which adds support for custom samplers](https://github.com/jack-berg/opentelemetry-java/commit/c8f611e5bab9a406acc3a11d65aefb07f0941e63)
- Add RuleBasedRoutingSampler implementation of ConfigurableSamplerProvider SPI, [like this commit](https://github.com/jack-berg/opentelemetry-java-contrib/commit/c09b3ae0f322dac39348c260dba917240a5bda9c). This requires that we define a configuration scheme, which becomes a lot more user friendly with file configuration with supports complex types. 
- Extend ConfigProperties to support complex types, as [prototyped here](https://github.com/open-telemetry/opentelemetry-java/pull/5873). This ensures that we RuleBasedRoutingSampler's configuration scheme doesn't need to be flattened.

If we do all this, we can reference RuleBasedRoutingSampler in file configuration, and specify its configuration with an ergonomic scheme that matches the programatic API:

```
# other configuration omitted for brevity
tracer_provider
  sampler:
    parent_based:
      root:
        rule_based_routing_sampler:
          fallback: always_on
          span_kind: SERVER
          drop_rules:
            - attribute: http.target
              pattern: "/actuator.*"
            - attribute: http.target
              pattern: "/foo"
```

I have all these changes made locally and published to maven local. I've updated the example to include spring boot, and the spring boot actuator which adds a health check endpoint (and various other /actuator.* endpoints) that users often want to drop.

If I run the app, and curl the health check endpoint we wish to drop (`curl localhost:8080/actuator/health`) and an application endpoint we wish to keep (`curl localhost:8080/ping`), we can see in the application output that we see the desired outcome:

```
11:22:36.459 [main] INFO io.opentelemetry.examples.fileconfig.Application - SDK config: OpenTelemetrySdk{tracerProvider=SdkTracerProvider{clock=SystemClock{}, idGenerator=RandomIdGenerator{}, resource=Resource{schemaUrl=null, attributes={service.name="file-configuration-example", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.31.0-SNAPSHOT"}}, spanLimitsSupplier=SpanLimitsValue{maxNumberOfAttributes=128, maxNumberOfEvents=128, maxNumberOfLinks=128, maxNumberOfAttributesPerEvent=128, maxNumberOfAttributesPerLink=128, maxAttributeValueLength=2147483647}, sampler=ParentBased{root:RuleBasedRoutingSampler{rules=[SamplingRule{attributeKey=http.target, delegate=AlwaysOffSampler, pattern=/actuator.*}, SamplingRule{attributeKey=http.target, delegate=AlwaysOffSampler, pattern=/foo}], kind=SERVER, fallback=AlwaysOnSampler},remoteParentSampled:AlwaysOnSampler,remoteParentNotSampled:AlwaysOffSampler,localParentSampled:AlwaysOnSampler,localParentNotSampled:AlwaysOffSampler}, spanProcessor=BatchSpanProcessor{spanExporter=LoggingSpanExporter{}, scheduleDelayNanos=5000000000, maxExportBatchSize=512, exporterTimeoutNanos=30000000000}}, meterProvider=SdkMeterProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.31.0-SNAPSHOT"}}, metricReaders=[], metricProducers=[], views=[]}, loggerProvider=SdkLoggerProvider{clock=SystemClock{}, resource=Resource{schemaUrl=null, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.31.0-SNAPSHOT"}}, logLimits=LogLimits{maxNumberOfAttributes=128, maxAttributeValueLength=2147483647}, logRecordProcessor=NoopLogRecordProcessor}, propagators=DefaultContextPropagators{textMapPropagator=MultiTextMapPropagator{textMapPropagators=[W3CTraceContextPropagator, W3CBaggagePropagator]}}}

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::               (v2.7.16)

2023-10-03 11:22:36.658  INFO 54858 --- [           main] i.o.examples.fileconfig.Application      : Starting Application using Java 17.0.3 on H6HJ6Q7NWV with PID 54858 (/Users/jberg/code/open-telemetry/opentelemetry-java-docs/file-configuration/build/classes/java/main started by jberg in /Users/jberg/code/open-telemetry/opentelemetry-java-docs/file-configuration)
2023-10-03 11:22:36.659  INFO 54858 --- [           main] i.o.examples.fileconfig.Application      : No active profile set, falling back to 1 default profile: "default"
2023-10-03 11:22:37.079  INFO 54858 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2023-10-03 11:22:37.084  INFO 54858 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2023-10-03 11:22:37.084  INFO 54858 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.80]
2023-10-03 11:22:37.135  INFO 54858 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2023-10-03 11:22:37.136  INFO 54858 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 462 ms
2023-10-03 11:22:37.373  INFO 54858 --- [           main] o.s.b.a.e.web.EndpointLinksResolver      : Exposing 1 endpoint(s) beneath base path '/actuator'
2023-10-03 11:22:37.393  INFO 54858 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path ''
2023-10-03 11:22:37.401  INFO 54858 --- [           main] i.o.examples.fileconfig.Application      : Started Application in 0.909 seconds (JVM running for 1.239)
2023-10-03 11:22:57.574  INFO 54858 --- [nio-8080-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2023-10-03 11:22:57.574  INFO 54858 --- [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2023-10-03 11:22:57.574  INFO 54858 --- [nio-8080-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 0 ms
2023-10-03 11:23:02.433  INFO 54858 --- [nio-8080-exec-3] i.o.examples.fileconfig.Controller       : A sample log message!
2023-10-03 11:23:06.466  INFO 54858 --- [_WorkerThread-1] i.o.e.logging.LoggingSpanExporter        : 'doWork' : 3bcf7160504bc63adb5cf95ef19b589a 82e0b9ff436898a6 INTERNAL [tracer: io.opentelemetry.examples.fileconfig.Application:] {}
2023-10-03 11:23:06.467  INFO 54858 --- [_WorkerThread-1] i.o.e.logging.LoggingSpanExporter        : 'GET /ping' : 3bcf7160504bc63adb5cf95ef19b589a d7f90c4a287ea4f7 SERVER [tracer: io.opentelemetry.spring-webmvc-5.3:1.29.0-alpha] AttributesMap{data={user_agent.original=curl/7.88.1, net.host.name=localhost, http.target=/ping, net.sock.peer.addr=127.0.0.1, http.status_code=200, net.protocol.name=http, http.method=GET, http.response_content_length=4, net.host.port=8080, net.protocol.version=1.1, http.scheme=http, net.sock.host.addr=127.0.0.1, net.sock.peer.port=50519, http.route=/ping}, capacity=128, totalAddedValues=14}
```

Notice I log the `OpenTelemetrySdk#toString()` at application start and we see `RuleBasedRoutingSampler` with our desired config.

Notice that we only see the `LoggingSpanExporter` print the span for `http.target=/ping`, and NOT for `http.target=/actuator/health`.

Let me know what you think! Hoping we can use this as a catalyst for landing these updates, and for ultimately packaging file based configuration and rule based routing sampler with the java agent.