### PR TITLE
Switch from spring dependency management to gradle platform

### DIFF
--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -1,9 +1,9 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
     id("java")
     id("org.springframework.boot") version "2.7.17"
-    id("io.spring.dependency-management") version "1.1.4"
 }
 
 description = "OpenTelemetry Example for Java Agent"
@@ -18,6 +18,7 @@ java {
 val agent = configurations.create("agent")
 
 dependencies {
+    implementation(platform(SpringBootPlugin.BOM_COORDINATES))
     implementation("io.opentelemetry:opentelemetry-api")
 
     //spring modules

--- a/micrometer-shim/build.gradle.kts
+++ b/micrometer-shim/build.gradle.kts
@@ -1,9 +1,9 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id("java")
     id("org.springframework.boot") version "2.7.17"
-    id("io.spring.dependency-management") version "1.1.4"
 }
 
 description = "OpenTelemetry Example for Micrometer Shim"
@@ -20,6 +20,7 @@ val bootRun = tasks.named<BootRun>("bootRun") {
 }
 
 dependencies {
+    implementation(platform(SpringBootPlugin.BOM_COORDINATES))
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
 

--- a/spring-native/build.gradle.kts
+++ b/spring-native/build.gradle.kts
@@ -1,21 +1,18 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
+
 plugins {
     id("java")
     id("org.springframework.boot") version "3.1.5"
-    id("io.spring.dependency-management") version "1.1.4"
     id("org.graalvm.buildtools.native") version "0.9.28"
 }
 
 description = "OpenTelemetry Example for Spring native images"
 val moduleName by extra { "io.opentelemetry.examples.native" }
 
-dependencyManagement {
-    imports {
-        mavenBom("io.opentelemetry:opentelemetry-bom:1.31.0")
-        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.32.0-alpha")
-    }
-}
-
 dependencies {
+    implementation(platform(SpringBootPlugin.BOM_COORDINATES))
+    implementation(platform("io.opentelemetry:opentelemetry-bom:1.31.0"))
+    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.32.0-alpha"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")
 }

--- a/telemetry-testing/build.gradle.kts
+++ b/telemetry-testing/build.gradle.kts
@@ -1,10 +1,10 @@
+import org.springframework.boot.gradle.plugin.SpringBootPlugin
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     id("java")
     id("org.springframework.boot") version "2.7.17"
-    id("io.spring.dependency-management") version "1.1.4"
 }
 
 description = "OpenTelemetry Example for Telemetry Testing"
@@ -27,6 +27,7 @@ val bootJar = tasks.named<BootJar>("bootJar") {
 }
 
 dependencies {
+    implementation(platform(SpringBootPlugin.BOM_COORDINATES))
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:1.32.0")
     //spring modules


### PR DESCRIPTION
Gradle platform has better performance than spring dependency-management plugin, especially during import into IDE. It also reduces complexity: one less plugin in the build.

It should also fix #210 according to this: https://github.com/renovatebot/renovate/issues/4614#issuecomment-557488428