### PR TITLE
remove empty objects from file-configuration

### DIFF
--- a/file-configuration/otel-sdk-config.yaml
+++ b/file-configuration/otel-sdk-config.yaml
@@ -9,18 +9,18 @@ tracer_provider:
   processors:
     - batch:
         exporter:
-          console: {}
+          console:
 
 meter_provider:
   readers:
     - periodic:
         exporter:
-          console: {}
+          console:
   views:
     - selector:
         instrument_type: histogram
       stream:
         aggregation:
-          drop: {}
+          drop:
 
 propagators: [tracecontext, baggage]


### PR DESCRIPTION
Now that we are past 1.31 which contained https://github.com/open-telemetry/opentelemetry-java/pull/5829 we can remove these empty objects

Resolves #218 