### PR TITLE
migrate gradle/gradle-build-action to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: 17
 
       - name: Build
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: clean check shadowJar
           cache-read-only: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -27,7 +27,7 @@ jobs:
           # see https://github.com/github/codeql-action/issues/1555#issuecomment-1452228433
           tools: latest
 
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
           # skipping build cache is needed so that all modules will be analyzed
           arguments: assemble --no-build-cache


### PR DESCRIPTION
See <https://github.com/gradle/gradle-build-action/blob/main/README.md>:

> As of `v3` this action has been superceded by `gradle/actions/setup-gradle`.
> Any workflow that uses `gradle/gradle-build-action@v3` will transparently delegate to `gradle/actions/setup-gradle@v3`.
>
> Users are encouraged to update their workflows, replacing:
> ```
> uses: gradle/gradle-build-action@v3
> ```
>
> with
> ```
> uses: gradle/actions/setup-gradle@v3
> ```
>
> See the [setup-gradle documentation](https://github.com/gradle/actions/tree/main/setup-gradle) for up-to-date documentation for `gradle/actions/setup-gradle`.