### PR TITLE
update spring native example and show AutoConfigurationCustomizerProvider

### DIFF
--- a/spring-native/README.md
+++ b/spring-native/README.md
@@ -11,6 +11,7 @@ The example uses the following elements:
   the [OTLP receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver)
   and exporting to the standard output with
   the [logging exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter).
+- A spring configuration to suppress spans for the `/actuator` endpoint
 
 # Description of the instrumentation set-up
 

--- a/spring-native/build.gradle.kts
+++ b/spring-native/build.gradle.kts
@@ -13,8 +13,12 @@ dependencies {
     implementation(platform(SpringBootPlugin.BOM_COORDINATES))
     implementation(platform("io.opentelemetry:opentelemetry-bom:1.36.0"))
     implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.2.0-alpha"))
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("com.h2database:h2")
     implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")
+
+    // for otelCustomizer in Application.java
+    implementation("io.opentelemetry.contrib:opentelemetry-samplers:1.33.0-alpha")
 }

--- a/spring-native/collector-spring-native-config.yaml
+++ b/spring-native/collector-spring-native-config.yaml
@@ -1,7 +1,7 @@
 receivers:
   otlp:
     protocols:
-      grpc:
+      http:
 exporters:
   logging:
     verbosity: detailed

--- a/spring-native/docker-compose.yml
+++ b/spring-native/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '3'
+version: '3.8'
 services:
   app:
     image: otel-native-graalvm
     environment:
       OTEL_SERVICE_NAME: "graal-native-example-app"
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4317"
-      # Logs are disabled by default
-      OTEL_LOGS_EXPORTER: "otlp"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318"
     ports:
       - "8080:8080"
     depends_on:

--- a/spring-native/src/main/java/io/opentelemetry/example/graal/Application.java
+++ b/spring-native/src/main/java/io/opentelemetry/example/graal/Application.java
@@ -1,12 +1,27 @@
 package io.opentelemetry.example.graal;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.contrib.sampler.RuleBasedRoutingSampler;
+import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class Application {
 
   public static void main(String[] args) {
     SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  public AutoConfigurationCustomizerProvider otelCustomizer() {
+    return p ->
+        p.addSamplerCustomizer(
+            (fallback, c) ->
+                RuleBasedRoutingSampler.builder(SpanKind.SERVER, fallback)
+                    .drop(SemanticAttributes.URL_PATH, "^/actuator")
+                    .build());
   }
 }

--- a/spring-native/src/main/resources/application.properties
+++ b/spring-native/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.datasource.url=jdbc:otel:h2:mem:db
 spring.datasource.driver-class-name=io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
+management.endpoints.web.exposure.include=*


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-java-examples/pull/227 also shows RuleBasedRoutingSampler, but using the new config file format.