### PR TITLE
Fix log-append collector can not output logs problem.

### DIFF
--- a/log-appender/docker-compose.yml
+++ b/log-appender/docker-compose.yml
@@ -4,6 +4,6 @@ services:
     image: otel/opentelemetry-collector-contrib:0.107.0
     volumes:
       - ./otel-config.yaml:/otel-config.yaml
-    command: ["--config=/otel-config.yaml","--feature-gates=-component.UseLocalHostAsDefaultHost"]
+    command: ["--config=/otel-config.yaml"]
     ports:
       - "4317:4317"

--- a/log-appender/docker-compose.yml
+++ b/log-appender/docker-compose.yml
@@ -4,6 +4,6 @@ services:
     image: otel/opentelemetry-collector-contrib:0.107.0
     volumes:
       - ./otel-config.yaml:/otel-config.yaml
-    command: ["--config=/otel-config.yaml"]
+    command: ["--config=/otel-config.yaml","--feature-gates=-component.UseLocalHostAsDefaultHost"]
     ports:
       - "4317:4317"

--- a/log-appender/otel-config.yaml
+++ b/log-appender/otel-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: collector:4317
 exporters:
   logging:
     verbosity: detailed


### PR DESCRIPTION
### Fix the issue #474 

**Description**: When using a new version of the collector image, using localhost instead of 0.0.0.0 would cause the host to be unable to report logs to the container, which was resolved by referring to this [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34394)

The logs are now printed properly!

![image](https://github.com/user-attachments/assets/a04cef70-31c1-492e-9ed4-44dad5dc5a25)
