### PR TITLE
Fix Java agent example

### DIFF
--- a/javaagent/collector-config.yaml
+++ b/javaagent/collector-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: "0.0.0.0:4318"
 exporters:
   logging:
     verbosity: detailed


### PR DESCRIPTION
The Java agent example is broken:

```
app-1        | [otel.javaagent 2024-09-10 15:07:14:681 +0000] [OkHttp http://collector:4318/...] ERROR io.opentelemetry.exporter.internal.http.HttpExporter - Failed to export logs. The request could not be executed. Full error message: Failed to connect to collector/172.21.0.2:4318
app-1        | java.net.ConnectException: Failed to connect to collector/172.21.0.2:4318
app-1        |  at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:297)
```

This PR fixes it.
