### PR TITLE
Update jaeger port for OTLP exporter

### DIFF
--- a/otlp/docker/otel-collector-config-demo.yaml
+++ b/otlp/docker/otel-collector-config-demo.yaml
@@ -17,7 +17,7 @@ exporters:
     format: proto
 
   otlp/jaeger:
-    endpoint: jaeger-all-in-one:14250
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 


### PR DESCRIPTION
Fixes #372 

Jaeger accepts OTLP on port 4317

This fix eliminates the error:

> error   exporterhelper/queue_sender.go:101      Exporting failed. Dropping data.        {"kind": "exporter", "data_type": "traces", "name": "otlp/jaeger", "error": "not retryable error: Permanent error: rpc error: code = Unimplemented desc = unknown service opentelemetry.proto.collector.trace.v1.TraceService", "dropped_items": 2}



And can see traces with this fix:

<img width="1899" alt="image" src="https://github.com/user-attachments/assets/5d6a9740-f0d7-4b45-9c75-05cde7c6ffa0">


