### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/javaagent/collector-config.yaml
+++ b/javaagent/collector-config.yaml
@@ -4,16 +4,16 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/log-appender/otel-config.yaml
+++ b/log-appender/otel-config.yaml
@@ -4,10 +4,10 @@ receivers:
       grpc:
         endpoint: collector:4317
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 service:
   pipelines:
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/otlp/docker/otel-collector-config-demo.yaml
+++ b/otlp/docker/otel-collector-config-demo.yaml
@@ -9,8 +9,8 @@ exporters:
     namespace: promexample
     const_labels:
       label1: value1
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -43,8 +43,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, otlp/jaeger]
+      exporters: [debug, zipkin, otlp/jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [debug, prometheus]

--- a/spring-native/collector-spring-native-config.yaml
+++ b/spring-native/collector-spring-native-config.yaml
@@ -4,16 +4,16 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037