### PR TITLE
Use slf4j instead of log4j in javaagent example

### DIFF
--- a/javaagent/src/main/java/io/opentelemetry/example/javagent/Controller.java
+++ b/javaagent/src/main/java/io/opentelemetry/example/javagent/Controller.java
@@ -9,8 +9,8 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.Random;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class Controller {
 
-  private static final Logger LOGGER = LogManager.getLogger(Controller.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Controller.class);
   private final AttributeKey<String> ATTR_METHOD = AttributeKey.stringKey("method");
 
   private final Random random = new Random();


### PR DESCRIPTION
The `./javaagent` example uses a Spring boot application, and spring boot's default log implementation is logback. The application uses the log4j API in application logging, which works, but is suboptimal. I discovered this when I tried to enable various experimental features in `opentelemetry-java-instrumentation`'s logback appender instrumentation and found that they didn't work. Apparently the context required to add things like thread and code calling information is lost when log4j is translated to slf4j to logback.

Switching the application logging to slf4j fixes the issue.