### PR TITLE
chore: update javaagent base image to eclipse-temurin:17-jre

### DIFF
--- a/javaagent/Dockerfile
+++ b/javaagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:17-jre
 
 ADD build/libs/app.jar /app.jar
 ADD build/agent/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar

--- a/javaagent/Dockerfile
+++ b/javaagent/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:21-jre
 
 ADD build/libs/app.jar /app.jar
 ADD build/agent/opentelemetry-javaagent.jar /opentelemetry-javaagent.jar

--- a/javaagent/build.gradle.kts
+++ b/javaagent/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
 description = "OpenTelemetry Example for Java Agent"
 val moduleName by extra { "io.opentelemetry.examples.javagent" }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 val agent = configurations.create("agent")
 val extension = configurations.create("extension")
 


### PR DESCRIPTION
Tried running the example and got this error during runtime:

```
java.lang.UnsupportedClassVersionError: org/springframework/boot/loader/launch/JarLauncher has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

The error message indicates that the JarLauncher class has been compiled with Java 17 (class file version 61.0), but we are trying to run it with Java 11 (class file version 55.0). To resolve this issue, we need to use a Java 17 runtime in your Dockerfile.

I tried updating the image to eclipse-temurin:17-jre, but then saw this error message:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: io/opentelemetry/example/javagent/Application has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
```

The error message indicates that the Application class has been compiled with Java 21 (class file version 65.0), but I was trying to run it with Java 17 (class file version 61.0). To resolve this issue, we need to use a Java 21 runtime in our Dockerfile.

Explicitly specifying the Java Language Version to 17 should compile the application with a version that works with the container image's runtime.