### PR TITLE
Clean up ExtendedSpanBuilder call chain in HTTP Server Example

### DIFF
--- a/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
+++ b/http/src/main/java/io/opentelemetry/example/http/HttpServer.java
@@ -48,15 +48,12 @@ public final class HttpServer {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-      // TODO (trask) clean up chaining after
-      // https://github.com/open-telemetry/opentelemetry-java/pull/6514
-      ((ExtendedSpanBuilder)
-              ((ExtendedSpanBuilder) tracer.spanBuilder("GET /"))
+      ((ExtendedSpanBuilder) tracer.spanBuilder("GET /"))
                   .setParentFrom(
                       openTelemetry.getPropagators(),
                       exchange.getRequestHeaders().entrySet().stream()
                           .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(0))))
-                  .setSpanKind(SpanKind.SERVER))
+                  .setSpanKind(SpanKind.SERVER)
           .startAndRun(
               () -> {
                 // Set the Semantic Convention


### PR DESCRIPTION
Clean up ExtendedSpanBuilder call chain in HTTP Sever Example according to merged: https://github.com/open-telemetry/opentelemetry-java/pull/6514 