### PR TITLE
Update GCP resource detection sample

### DIFF
--- a/resource-detection-gcp/build.gradle.kts
+++ b/resource-detection-gcp/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
     implementation("io.opentelemetry:opentelemetry-exporter-logging-otlp")
-    implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources:1.34.0-alpha")
+    implementation("io.opentelemetry.contrib:opentelemetry-gcp-resources:1.42.0-alpha")
 }
 
 jib {

--- a/resource-detection-gcp/k8s/job.yaml
+++ b/resource-detection-gcp/k8s/job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: hello-resource-java
-          image: gcr.io/%GOOGLE_CLOUD_PROJECT%/hello-resource-java:latest
+          image: "%REGISTRY_LOCATION%-docker.pkg.dev/%GOOGLE_CLOUD_PROJECT%/%ARTIFACT_REGISTRY%/hello-resource-java:latest"
           env:
             - name: OTEL_TRACES_EXPORTER
               value: none
@@ -28,12 +28,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: NAMESPACE
+            - name: NAMESPACE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CONTAINER_NAME
               value: hello-resource-java
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME),k8s.container.name=$(CONTAINER_NAME)
       # Do not restart containers after they exit
       restartPolicy: Never
   # of retries before marking as failed.


### PR DESCRIPTION
### Description
Updates the GCP Resource detection sample:
 - Use Google Cloud Artifact Registry instead of Google Cloud Container Registry (now deprecated).
 - Updates `job.yaml` to set proper environment variables so the following attributes can be detected by OpenTelemetry:
     - `container.name`
     - `k8s.pod.name`
     - `k8s.namespace.name`
 - Bumped the gcp-resource-detector dependency version.
 - Add cleanup instructions.

### Testing
Manually ran the sample following the updated instructions.