### PR TITLE
Ignore locally built dice image in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,13 @@
       // not using matchUpdateTypes "major", because renovate wants to bump "11-jre" to "11.0.19_7-jre"
       "matchPackageNames": ["eclipse-temurin"],
       "enabled": false
+    },
+    {
+      // Skip locally built dice image used in logging-k8s-stdout-otlp-json
+      "matchManagers": ["kubernetes"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["dice"],
+      "enabled": false
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
Related to #160 

> Renovate failed to look up the following dependencies: Failed to look up docker package dice.
> Files affected: logging-k8s-stdout-otlp-json/k8s/dice.yaml

This image is built locally via the [k3d.sh script](https://github.com/open-telemetry/opentelemetry-java-examples/blob/main/logging-k8s-stdout-otlp-json/k3d.sh) and is not pulled from a registry