### PR TITLE
Reduce repo settings we need to doc

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,4 +1,3 @@
 # Repository settings
 
-Same as [opentelemetry-java-instrumentation repository settings](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/repository-settings.md#repository-settings),
-except that the branch protection rules for `release/*`, `gh-pages`, and `opentelemetrybot/*` are not needed in this repository.
+Same as [opentelemetry-java-instrumentation repository settings](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/repository-settings.md#repository-settings).


### PR DESCRIPTION
Most of the settings are now tracked via IaC (https://github.com/open-telemetry/community/issues/1596).