### PR TITLE
Fix prom version tag

### DIFF
--- a/otlp/docker/docker-compose.yaml
+++ b/otlp/docker/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
 
   prometheus:
     container_name: prometheus
-    image: prom/prometheus:3.4.1@sha256:9abc6cf6aea7710d163dbb28d8eeb7dc5baef01e38fa4cd146a406dd9f07f70d
+    image: prom/prometheus:v3.4.1@sha256:9abc6cf6aea7710d163dbb28d8eeb7dc5baef01e38fa4cd146a406dd9f07f70d
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yml
     ports:


### PR DESCRIPTION
Should fix the Renovate warning

> [!WARNING]
> Renovate failed to look up the following dependencies: `Could not determine new digest for update (docker package prom/prometheus)`.
> 
> Files affected: `otlp/docker/docker-compose.yaml`
