### PR TITLE
Fix codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
       issues: write
     needs:
       - analyze
-    if: always()
+    if: always() && github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.analyze.result == 'success' }}


### PR DESCRIPTION
Only want to auto-create issues during the scheduled run (since otherwise it can be easy to miss those failures)