### PR TITLE
Fix declarative configuration example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,26 @@ jobs:
 
       - run: java -cp sdk-usage/build/libs/opentelemetry-examples-sdk-usage-0.1.0-SNAPSHOT-all.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample
 
+  test-declarative-configuration-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Run declarative-configuration
+        working-directory: declarative-configuration
+        run: ../gradlew run
+
   # this is not a required check to avoid blocking pull requests if external links break
   markdown-link-check:
     uses: ./.github/workflows/reusable-markdown-link-check.yml
@@ -49,8 +69,11 @@ jobs:
   required-status-check:
     needs:
       - build
+      - test-declarative-configuration-run
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - if: needs.build.result != 'success'
+      - if: >
+          needs.build.result != 'success' ||
+          needs.test-declarative-configuration-run.result != 'success'
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
 
       - name: Run declarative-configuration
         working-directory: declarative-configuration
-        run: ../gradlew run
+        run: |
+          export OTEL_EXPERIMENTAL_CONFIG_FILE=$(pwd)/otel-sdk-config.yaml
+          ../gradlew run
 
   # this is not a required check to avoid blocking pull requests if external links break
   markdown-link-check:

--- a/declarative-configuration/otel-sdk-config.yaml
+++ b/declarative-configuration/otel-sdk-config.yaml
@@ -1,11 +1,16 @@
 # See https://github.com/open-telemetry/opentelemetry-configuration for details on schema and examples
 
-file_format: "0.3"
+file_format: "1.0-rc.1"
 
 resource:
   attributes:
     - name: service.name
       value: file-configuration-example
+
+propagator:
+  composite:
+    - tracecontext:
+    - baggage:
 
 tracer_provider:
   processors:
@@ -24,8 +29,3 @@ meter_provider:
       stream:
         aggregation:
           drop:
-
-propagator:
-  composite:
-    - tracecontext
-    - baggage


### PR DESCRIPTION
The declarative config example was broken. I fixed it and added a github action step to run it on PRs so we'll get alerted to this in the future.

This example was failing with:

> Task :opentelemetry-examples-declarative-configuration:run FAILED
Exception in thread "main" io.opentelemetry.api.incubator.config.DeclarativeConfigException: Unable to parse configuration input stream
        at io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration.parse(DeclarativeConfiguration.java:142)
        at io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration.parseAndCreate(DeclarativeConfiguration.java:86)
        at io.opentelemetry.examples.fileconfig.Application.main(Application.java:31)
Caused by: java.lang.IllegalArgumentException: Cannot construct instance of `io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TextMapPropagatorModel` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('tracecontext')
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel["propagator"]->io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PropagatorModel["composite"]->java.util.ArrayList[0])
        at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4663)
        at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4594)
        at io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration.parse(DeclarativeConfiguration.java:150)
        at io.opentelemetry.sdk.extension.incubator.fileconfig.DeclarativeConfiguration.parse(DeclarativeConfiguration.java:140)
        ... 2 more
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.TextMapPropagatorModel` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('tracecontext')
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.OpenTelemetryConfigurationModel["propagator"]->io.opentelemetry.sdk.extension.incubator.fileconfig.internal.model.PropagatorModel["composite"]->java.util.ArrayList[0])...