### PR TITLE
fix: missing annotation in Annotation example

### DIFF
--- a/doc-snippets/spring-starter/src/main/java/otel/TracedClass.java
+++ b/doc-snippets/spring-starter/src/main/java/otel/TracedClass.java
@@ -23,5 +23,6 @@ public class TracedClass {
   @WithSpan(kind = SpanKind.CLIENT)
   public void tracedClientSpan() {}
 
+  @WithSpan
   public void tracedMethodWithAttribute(@SpanAttribute("attributeName") String parameter) {}
 }


### PR DESCRIPTION
## Summary

- Added missing `@WithSpan` annotation to `tracedMethodWithAttribute` method in `TracedClass.java`

After this PR is merged, I would like to fix the below document.

https://opentelemetry.io/docs/zero-code/java/spring-boot-starter/annotations/
