### PR TITLE
Renovate: Suppress SNAPSHOT updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,7 @@
       // major.minor.patch, under the assumption that you would want to update to the stable version
       // of that release instead of the unstable version for a future release
       "ignoreUnstable": false
+      allowedVersions: '!/\\-SNAPSHOT$/',
     },
     {
       groupName: 'opentelemetry instrumentation packages',


### PR DESCRIPTION
Port of https://github.com/open-telemetry/opentelemetry-java-contrib/pull/2448

(already doing this in core and instrumentation repos)