### PR TITLE
fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,7 +43,7 @@
     {
       // Spring starter doesn't support Spring Boot 4 yet
       "matchPackageNames": ["org.springframework.boot"],
-      "matchFilePatterns": [
+      "matchFileNames": [
         "doc-snippets/spring-starter/build.gradle.kts",
         "spring-native/build.gradle.kts"
       ],


### PR DESCRIPTION
manually checked with `docker run --rm --volume=$(pwd):$(pwd):ro --workdir=$(pwd) kokuwaio/renovate-config-validator`

(https://github.com/super-linter/super-linter also lints it)