### PR TITLE
Update link to style guide reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ mise run lint:markdown --fix
 ## Style guide
 
 This repository follows the OpenTelemetry Java
-repository's [style guide](https://github.com/open-telemetry/opentelemetry-java/blob/main/CONTRIBUTING.md#style-guideline).
+repository's [patterns](https://github.com/open-telemetry/opentelemetry-java/blob/main/docs/knowledge/general-patterns.md).
 
 ## Gradle conventions
 


### PR DESCRIPTION
Link checking is failing because there is no longer a style guide section in the contributing doc in the core repo. I updated the link to the general patterns doc, but open to ideas if i should instead reference something else, like the [instrumentation style guide](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/docs/contributing/style-guide.md) as an example