### PR TITLE
Relax brittle OATS log attribute assertions

### DIFF
--- a/logging-k8s-stdout-otlp-json/oats.yaml
+++ b/logging-k8s-stdout-otlp-json/oats.yaml
@@ -32,7 +32,6 @@ expected:
         # thread_name: ".*" # thread name is missing when there is an exception - has nothing to do with stdout logging
         span_id: ".*"
         trace_id: ".*"
-        container_id: ".*"
         host_arch: ".*"
         host_name: ".*"
         os_description: ".*"
@@ -51,6 +50,4 @@ expected:
         telemetry_sdk_name: ".*"
         telemetry_sdk_version: ".*"
         exception_stacktrace: "java\\.lang\\.RuntimeException: simulating an error\n\tat io\\.opentelemetry\\.example\\.RollController\\.index\\(RollController\\.java:21\\)\n\t.*\n"
-
-      no-extra-attributes: true
 


### PR DESCRIPTION
The last release detected a bogus UUID as containter ID that is rejected in the latest agent version