### PR TITLE
chore: Switch to Jaeger image v2

### DIFF
--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -25,7 +25,7 @@ docker run --rm -it --name jaeger\
   -e COLLECTOR_OTLP_ENABLED=true \
   -p 4317:4317 \
   -p 16686:16686 \
-  jaegertracing/all-in-one:1.39
+  jaegertracing/jaeger
 ```
 
 ## 3 - Start the Application

--- a/otlp/docker/docker-compose.yaml
+++ b/otlp/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Jaeger
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:1.76.0@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     ports:
       - "16686:16686"
       - "14268"


### PR DESCRIPTION
The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321