### PR TITLE
feat: add Spring ConfigProvider example

### DIFF
--- a/spring-declarative-configuration/README.md
+++ b/spring-declarative-configuration/README.md
@@ -30,7 +30,7 @@ This Spring Boot application includes two endpoints:
 ### Prerequisites
 
 - Java 17 or higher
-- OpenTelemetry Spring Boot Starter **2.22.0+** on the classpath of this application (already
+- OpenTelemetry Spring Boot Starter **2.30.0+** on the classpath of this application (already
   configured in this example’s [build file](./build.gradle.kts))
 
 ### Step 1: Build the Application
@@ -202,6 +202,18 @@ Here, `http://localhost:4318` is used as the default if the `OTEL_EXPORTER_OTLP_
 environment variable is not set.
 
 When copying configuration from non-Spring examples, always convert `:-` to `:` in placeholders.
+
+## Read instrumentation configuration programmatically
+
+Starting with version 2.30.0, the OpenTelemetry Spring Boot Starter exposes a `ConfigProvider`
+Spring bean. The [`ReadInstrumentationConfig`](./src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java)
+component demonstrates how application code can inject this bean and read instrumentation
+configuration.
+
+`ConfigProvider#getInstrumentationConfig()` returns the `instrumentation/development` configuration
+tree. This example walks through `java.common.db.query_sanitization` and reads the `enabled` value,
+defaulting to `true` when it is not configured. The same tree is used whether the setting comes from
+an `otel.instrumentation.*` property or the equivalent declarative YAML configuration.
 
 ## Declarative vs Programmatic Configuration
 

--- a/spring-declarative-configuration/build.gradle.kts
+++ b/spring-declarative-configuration/build.gradle.kts
@@ -17,7 +17,7 @@ java {
 
 dependencies {
     implementation(platform(SpringBootPlugin.BOM_COORDINATES))
-    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.29.0"))
+    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom:2.30.0"))
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter")

--- a/spring-declarative-configuration/src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java
+++ b/spring-declarative-configuration/src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java
@@ -23,10 +23,10 @@ public class ReadInstrumentationConfig {
     DeclarativeConfigProperties dbConfig =
         configProvider
             .getInstrumentationConfig()
-            .getStructured("java")
-            .getStructured("common")
-            .getStructured("db")
-            .getStructured("query_sanitization");
+            .get("java")
+            .get("common")
+            .get("db")
+            .get("query_sanitization");
     return dbConfig.getBoolean("enabled", true);
   }
 }

--- a/spring-declarative-configuration/src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java
+++ b/spring-declarative-configuration/src/main/java/io/opentelemetry/examples/fileconfig/ReadInstrumentationConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.examples.fileconfig;
+
+import io.opentelemetry.api.incubator.config.ConfigProvider;
+import io.opentelemetry.api.incubator.config.DeclarativeConfigProperties;
+import org.springframework.stereotype.Component;
+
+/** Example of reading instrumentation configuration from application code. */
+@Component
+public class ReadInstrumentationConfig {
+
+  private final ConfigProvider configProvider;
+
+  public ReadInstrumentationConfig(ConfigProvider configProvider) {
+    this.configProvider = configProvider;
+  }
+
+  public boolean isDbQuerySanitizationEnabled() {
+    DeclarativeConfigProperties dbConfig =
+        configProvider
+            .getInstrumentationConfig()
+            .getStructured("java")
+            .getStructured("common")
+            .getStructured("db")
+            .getStructured("query_sanitization");
+    return dbConfig.getBoolean("enabled", true);
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `ReadInstrumentationConfig` Spring component that demonstrates reading an instrumentation setting through the `ConfigProvider` bean.
- Update the Spring declarative configuration example to the OpenTelemetry Spring Boot Starter 2.30.0 BOM, which provides the `ConfigProvider` bean.

## Test plan

- `mise run lint` ✅
- `./gradlew assemble` passed before the required 2.30.0 dependency bump with the same source change.
- Final Gradle validation is pending Maven Central publication of the newly released 2.30.0 BOM; it currently returns 404.
