### PR TITLE
ci: lint dotenv files with Flint

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,8 @@ k3d = "5.8.3"
 kubectl = "1.36.2"
 
 # Linters
-"aqua:grafana/flint" = "0.22.9"
+"aqua:dotenv-linter/dotenv-linter" = "4.0.0"
+"cargo:https://github.com/grafana/flint" = "rev:1cd44f7"
 lychee = "0.24.2"
 rumdl = "0.2.38"
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 [tools]
-"aqua:dotenv-linter/dotenv-linter" = "4.0.0"
 "aqua:grafana/oats" = "0.7.0"
 k3d = "5.8.3"
 kubectl = "1.36.3"
 
 # Linters
 "aqua:grafana/flint" = "0.22.10"
+dotenv-linter = "4.0.0"
 lychee = "0.24.2"
 rumdl = "0.2.43"
 

--- a/otlp/docker/.env
+++ b/otlp/docker/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib:latest
 OTELCOL_ARGS=
+OTELCOL_IMG=otel/opentelemetry-collector-contrib:latest


### PR DESCRIPTION
## Summary

- enable dotenv file linting through Flint
- install dotenv-linter 4.0.0 through its Aqua registry package
- fix the ordering issue found in `otlp/docker/.env`

This adopts the released dotenv-linter support from [Flint v0.22.10](https://github.com/grafana/flint/releases/tag/v0.22.10) using the standard `aqua:grafana/flint` backend.

## Testing

- `mise exec -- flint run --full dotenv-linter`
- `dotenv-linter fix --plain --no-backup otlp/docker/.env`
- `mise run lint`
- `mise exec -- ./gradlew assemble`
