### PR TITLE
Reduce Gradle cache writers and converge the remote cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,15 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ github.event_name == 'pull_request' }}
+          cache-read-only: ${{ github.event_name != 'push' || github.ref_name != github.event.repository.default_branch }}
+          gradle-home-cache-excludes: >-
+            ${{ matrix.os == 'ubuntu-latest' && secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && 'caches/build-cache-1' || '' }}
 
       - name: Build
         run: ./gradlew clean check shadowJar
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: >-
+            ${{ matrix.os == 'ubuntu-latest' && github.ref_name == github.event.repository.default_branch && secrets.DEVELOCITY_ACCESS_KEY || '' }}
 
       - run: java -cp sdk-usage/build/libs/opentelemetry-examples-sdk-usage-0.1.0-SNAPSHOT-all.jar io.opentelemetry.sdk.example.ConfigureSpanProcessorExample
 
@@ -62,15 +65,13 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ github.event_name == 'pull_request' }}
+          cache-read-only: true
 
       - name: Run declarative-configuration
         working-directory: declarative-configuration
         run: |
           export OTEL_EXPERIMENTAL_CONFIG_FILE=$(pwd)/otel-sdk-config.yaml
           ../gradlew run
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
   lint:
     uses: ./.github/workflows/reusable-lint-check.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Set up gradle
         if: matrix.language == 'java'
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
@@ -57,8 +59,6 @@ jobs:
         # --no-daemon is required for codeql to observe the compilation
         # (see https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#specifying-build-commands)
         run: ./gradlew assemble --no-build-cache --no-daemon
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/oats-tests.yml
+++ b/.github/workflows/oats-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ github.event_name == 'pull_request' }}
+          cache-read-only: true
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
 

--- a/.github/workflows/prometheus-test.yml
+++ b/.github/workflows/prometheus-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          cache-read-only: ${{ github.event_name == 'pull_request' }}
+          cache-read-only: true
 
       - name: Run Prometheus test
         run: .github/scripts/prometheus-test.sh

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,9 @@ plugins {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
+val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
+val shouldDisableLocalBuildCache =
+    isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF_NAME") == "main"
 
 develocity {
     if (develocityAccessKey.isNotEmpty()) {
@@ -45,9 +48,15 @@ develocity {
 }
 
 buildCache {
-    remote(HttpBuildCache::class) {
-        url = uri("$develocityServer/cache/")
-        isPush = isCI && develocityAccessKey.isNotEmpty()
+    // Tasks restored from the local cache are never pushed to the remote cache. Disable the local
+    // cache on the authenticated main build so the remote cache converges on complete.
+    local {
+        isEnabled = !shouldDisableLocalBuildCache
+    }
+
+    remote(develocity.buildCache) {
+        server = develocityServer
+        isPush = isRemoteBuildCachePushEnabled
     }
 }
 


### PR DESCRIPTION
Applies the cache fixes from [opentelemetry-java-instrumentation#19532](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19532) and [opentelemetry-java-instrumentation#19533](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19533) to reduce GitHub Actions cache pressure and improve Develocity remote cache coverage.