### PR TITLE
Group Renovate minor updates and schedule majors weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,13 +13,13 @@
       "groupName": "all patch and minor versions",
       "matchUpdateTypes": ["patch", "digest", "minor"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
-      "matchPackageNames": ["!io.opentelemetry**"]
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // majors stay individual, but arrive on the weekly schedule
       "matchUpdateTypes": ["major"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
-      "matchPackageNames": ["!io.opentelemetry**"]
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // group all GitHub Actions updates into a single weekly PR

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,8 +10,14 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch", "digest"],
+      "groupName": "all patch and minor versions",
+      "matchUpdateTypes": ["patch", "digest", "minor"],
+      "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
+      "matchPackageNames": ["!io.opentelemetry**"]
+    },
+    {
+      // majors stay individual, but arrive on the weekly schedule
+      "matchUpdateTypes": ["major"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
       "matchPackageNames": ["!io.opentelemetry**"]
     },


### PR DESCRIPTION
Renovate opens a separate PR for every non-OpenTelemetry minor update, because the config only groups patch and digest updates. In the last 90 days that produced 56 individual PRs out of 85. `org.mock-server:mockserver-netty` alone went from v6 to v7.5 across 9 separate PRs. This change folds minor updates into the existing weekly group and puts majors on the same weekly schedule, so they still arrive as individual PRs but only once a week.

OpenTelemetry updates are excluded from both rules and keep landing immediately and individually, so dogfooding and cascaded releases are unchanged. The exclusion covers the `io.opentelemetry**` Maven coordinates as before, and now also `open-telemetry/**`, which is the GitHub tag that `logging-k8s-stdout-otlp-json` tracks.

The `otel/opentelemetry-collector-contrib` and `grafana/otel-lgtm` Docker images do join the weekly group. That is deliberate, because they are test infrastructure rather than cascaded releases.
