### PR TITLE
Group Renovate minor updates and schedule majors weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,13 +13,13 @@
       "groupName": "all patch and minor versions",
       "matchUpdateTypes": ["patch", "digest", "minor"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
-      "matchPackageNames": ["!io.opentelemetry**"]
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // majors stay individual, but arrive on the weekly schedule
       "matchUpdateTypes": ["major"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
-      "matchPackageNames": ["!io.opentelemetry**"]
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // group all GitHub Actions updates into a single weekly PR

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,8 +10,14 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch", "digest"],
+      "groupName": "all patch and minor versions",
+      "matchUpdateTypes": ["patch", "digest", "minor"],
+      "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
+      "matchPackageNames": ["!io.opentelemetry**"]
+    },
+    {
+      // majors stay individual, but arrive on the weekly schedule
+      "matchUpdateTypes": ["major"],
       "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
       "matchPackageNames": ["!io.opentelemetry**"]
     },


### PR DESCRIPTION
Renovate opens a separate pull request for every non-OpenTelemetry minor update, because the config groups only patch and digest updates. That produced 56 individual pull requests out of 85 in the last 90 days. `org.mock-server:mockserver-netty` alone took 9 of them to go from v6 to v7.5.

Minor updates now fold into the weekly group, and majors move to the same weekly schedule, so they still arrive individually but only once a week.

OpenTelemetry updates are excluded from both rules and keep landing immediately and individually, so dogfooding and cascaded releases are unchanged. The exclusion now also covers `open-telemetry/**`, the GitHub tag that `logging-k8s-stdout-otlp-json` tracks.

The `otel/opentelemetry-collector-contrib` and `grafana/otel-lgtm` images do join the weekly group. That is deliberate, since they are test infrastructure rather than cascaded releases.
