### PR TITLE
Migrate to the OSS Community Develocity Instance

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.develocity")
 }
 
-val develocityServer = "https://develocity.opentelemetry.io"
+val develocityServer = "https://community.develocity.cloud"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
 val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
@@ -24,6 +24,7 @@ val shouldDisableLocalBuildCache =
 develocity {
     if (develocityAccessKey.isNotEmpty()) {
         server = develocityServer
+        projectId = "OpenTelemetry"
     }
 
     buildScan {


### PR DESCRIPTION
# Migrate to the OSS Community Develocity Instance

OpenTelemetry's dedicated Develocity instance (`https://develocity.opentelemetry.io`) is being
retired in favour of the shared **OSS Community Develocity Instance** at
<https://community.develocity.cloud>, which Develocity (Gradle Inc.) runs for OSS projects.
Build Scans and the remote build cache keep working exactly as they do today — only the host
changes, and builds are now associated with the `OpenTelemetry` project on the shared instance.

## What this PR changes

- `settings.gradle.kts`: `develocityServer` now points at `https://community.develocity.cloud`.
- `settings.gradle.kts`: adds `projectId = "OpenTelemetry"` so Build Scans and cache entries are
  scoped to the OpenTelemetry project on the shared instance.

Nothing else changes: the CI workflows already read `DEVELOCITY_ACCESS_KEY` from secrets, so no
workflow edits are needed. Build Scan publishing, remote cache push, and the
`build-scan.txt` output all behave as before.

## Action required before/when merging

The `DEVELOCITY_ACCESS_KEY` secret must be updated, because the access key format is
`<host>=<key>` and the host is changing:

```
DEVELOCITY_ACCESS_KEY = community.develocity.cloud=<access-key-for-the-community-instance>
```

Access keys for the OpenTelemetry CI service account on `community.develocity.cloud` have been
provisioned by the Develocity team and shared with the maintainers out of band. If the secret
still carries the `develocity.opentelemetry.io=` prefix after this PR merges, the key is silently
ignored: CI builds will publish no Build Scans and will not push to the remote cache.

Because the secret is shared across the OpenTelemetry JVM repositories, the cleanest sequence is
to update the (org-level) secret and merge the per-repository PRs together.

## Related PRs

This is part of the OpenTelemetry migration to the Community Instance. Companion PRs:

- open-telemetry/opentelemetry-java#8760
- open-telemetry/opentelemetry-java-instrumentation#19927
- open-telemetry/opentelemetry-java-contrib#3085
- open-telemetry/opentelemetry-java-examples#1262  ← this PR
- open-telemetry/semantic-conventions-java#569
- open-telemetry/opentelemetry-proto-java#279

## Questions

Happy to adjust anything here — feel free to ping me on this PR or in the CNCF Slack.
