### PR TITLE
Fix gradle warning about processing duplicate kotlin module files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id("com.diffplug.spotless")
     id("com.gradleup.shadow") apply false
@@ -25,6 +27,15 @@ subprojects {
         java {
             targetExclude("**/generated/**")
             googleJavaFormat()
+        }
+    }
+
+    pluginManager.withPlugin("com.gradleup.shadow") {
+        tasks.withType<ShadowJar>().configureEach {
+            // avoid warning about duplicate kotlin module files being silently dropped
+            filesMatching("META-INF/*.kotlin_module") {
+                duplicatesStrategy = DuplicatesStrategy.INCLUDE
+            }
         }
     }
 }

--- a/grpc/build.gradle.kts
+++ b/grpc/build.gradle.kts
@@ -58,4 +58,8 @@ protobuf {
 
 tasks.shadowJar {
     mergeServiceFiles()
+    // mergeServiceFiles requires that duplicate strategy is set to include
+    filesMatching("META-INF/services/**") {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 }


### PR DESCRIPTION
> 'META-INF/okhttp.kotlin_module' is matched by com.github.jengelman.gradle.plugins.shadow.transformers.KotlinModuleMetadataTransformer_Decorated but its DuplicatesStrategy is EXCLUDE — duplicates may be silently dropped before the transformer processes them.
Set it to INCLUDE or WARN to ensure all duplicates are processed by the transformer.

also fixes warning about merging service files
> 'META-INF/services/io.grpc.LoadBalancerProvider' is matched by com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer but its DuplicatesStrategy is EXCLUDE — duplicates may be silently dropped before the transformer processes them.
Set it to INCLUDE or WARN to ensure all duplicates are processed by the transformer.